### PR TITLE
Link release candidate link to 1.0rc2

### DIFF
--- a/downloads.php
+++ b/downloads.php
@@ -112,7 +112,7 @@
     <div class="download-notes text-center">
       <p>
         <?php echo _("The release of FreeCAD 1.0 is happening soon! Help us squashing last-minute bugs"); ?>:
-        <a class="badge text-bg-light text-decoration-none" href="https://github.com/FreeCAD/FreeCAD/releases/tag/1.0rc1">
+        <a class="badge text-bg-light text-decoration-none" href="https://github.com/FreeCAD/FreeCAD/releases/tag/1.0rc2">
             <?php echo _('Download and try a 1.0 Release Candidate build!'); ?>
         </a>
       </p>


### PR DESCRIPTION
The [blog post](https://blog.freecad.org/2024/09/24/the-second-release-candidate-of-freecad-1-0-is-out/) has link to the new 1.0rc2 build.
To avoid confusion, I think we should change the link on the download page too, so it points to 1.0rc2.